### PR TITLE
add distribution archives for all tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         provider: releases
         api_key:
           secure: KARrS20Qud7MMa4NCxmKIbDeMeeA83Wb+a+O22vIGXOk8IJeG6EcUF+gRsnbT+ARqrKdRZIS84OUB/aebgNLT+j2bk8L+UoBQuz6J6JHDqz1duoVa5CK5bIopVEBfu44ZBXHdE01XWLgGS1ce027iCCk0VRAAjpKDVG2X83YONxClg+cCOc6EpVXviHsxnoMSyOpgxTXQRgdgmv1XyzbBTyYKKFWbtNg7AUbxQ0ngQf800+0OmHLZ7ooILlRH115DQ0KJQeKyegCdjJ0Uc4uoSlqVF1VXKvwCColWT3MHU/U9Ig6Edqloh8ulM3BVhnORrwYwJ+oScfzPUPkg9kwzDdA4QgAhdKHKjOa9V62vPlz/oq4fD4LRs81BHiHQVo/WFK+UTkvrqYpDi+hiFfuob8N4sUGckXP8eEVyY2XP5fCMzkhwe2Xnz2CvWqoLt6v6LeZzYFQs68ZwGuwfKn22PqkuyvO+H3X4qqe7F60ofIl9OjJCeLuIpGovG13t/ivNlRiVk8OYaYQQK6OGDVhVqeWI81GXNrttPQygLStr6nnaQo6Gawtsrwk5/OL2ztKrzypXMy+8o2AaQyxrtaGJxnDv8MMkiv0AN2r3uAAfpS2N8xaImeD0R6/EB9W/P/S54KzxyCvsgcVQ0OHJq1LmICHipzFL7lSj7wBmlXmaiA=
-        file: ethoxy-*-$TRAVIS_OS_NAME.*
+        file: multi-geth*-$TRAVIS_OS_NAME.*
         file_glob: true
         draft: true
         on:
@@ -48,7 +48,7 @@ matrix:
         provider: releases
         api_key:
           secure: KARrS20Qud7MMa4NCxmKIbDeMeeA83Wb+a+O22vIGXOk8IJeG6EcUF+gRsnbT+ARqrKdRZIS84OUB/aebgNLT+j2bk8L+UoBQuz6J6JHDqz1duoVa5CK5bIopVEBfu44ZBXHdE01XWLgGS1ce027iCCk0VRAAjpKDVG2X83YONxClg+cCOc6EpVXviHsxnoMSyOpgxTXQRgdgmv1XyzbBTyYKKFWbtNg7AUbxQ0ngQf800+0OmHLZ7ooILlRH115DQ0KJQeKyegCdjJ0Uc4uoSlqVF1VXKvwCColWT3MHU/U9Ig6Edqloh8ulM3BVhnORrwYwJ+oScfzPUPkg9kwzDdA4QgAhdKHKjOa9V62vPlz/oq4fD4LRs81BHiHQVo/WFK+UTkvrqYpDi+hiFfuob8N4sUGckXP8eEVyY2XP5fCMzkhwe2Xnz2CvWqoLt6v6LeZzYFQs68ZwGuwfKn22PqkuyvO+H3X4qqe7F60ofIl9OjJCeLuIpGovG13t/ivNlRiVk8OYaYQQK6OGDVhVqeWI81GXNrttPQygLStr6nnaQo6Gawtsrwk5/OL2ztKrzypXMy+8o2AaQyxrtaGJxnDv8MMkiv0AN2r3uAAfpS2N8xaImeD0R6/EB9W/P/S54KzxyCvsgcVQ0OHJq1LmICHipzFL7lSj7wBmlXmaiA=
-        file: ethoxy-*-$TRAVIS_OS_NAME.*
+        file: multi-geth*-$TRAVIS_OS_NAME.*
         file_glob: true
         draft: true
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         provider: releases
         api_key:
           secure: KARrS20Qud7MMa4NCxmKIbDeMeeA83Wb+a+O22vIGXOk8IJeG6EcUF+gRsnbT+ARqrKdRZIS84OUB/aebgNLT+j2bk8L+UoBQuz6J6JHDqz1duoVa5CK5bIopVEBfu44ZBXHdE01XWLgGS1ce027iCCk0VRAAjpKDVG2X83YONxClg+cCOc6EpVXviHsxnoMSyOpgxTXQRgdgmv1XyzbBTyYKKFWbtNg7AUbxQ0ngQf800+0OmHLZ7ooILlRH115DQ0KJQeKyegCdjJ0Uc4uoSlqVF1VXKvwCColWT3MHU/U9Ig6Edqloh8ulM3BVhnORrwYwJ+oScfzPUPkg9kwzDdA4QgAhdKHKjOa9V62vPlz/oq4fD4LRs81BHiHQVo/WFK+UTkvrqYpDi+hiFfuob8N4sUGckXP8eEVyY2XP5fCMzkhwe2Xnz2CvWqoLt6v6LeZzYFQs68ZwGuwfKn22PqkuyvO+H3X4qqe7F60ofIl9OjJCeLuIpGovG13t/ivNlRiVk8OYaYQQK6OGDVhVqeWI81GXNrttPQygLStr6nnaQo6Gawtsrwk5/OL2ztKrzypXMy+8o2AaQyxrtaGJxnDv8MMkiv0AN2r3uAAfpS2N8xaImeD0R6/EB9W/P/S54KzxyCvsgcVQ0OHJq1LmICHipzFL7lSj7wBmlXmaiA=
-        file: multi-geth-$TRAVIS_OS_NAME.*
+        file: ethoxy-*-$TRAVIS_OS_NAME.*
         file_glob: true
         draft: true
         on:
@@ -48,7 +48,7 @@ matrix:
         provider: releases
         api_key:
           secure: KARrS20Qud7MMa4NCxmKIbDeMeeA83Wb+a+O22vIGXOk8IJeG6EcUF+gRsnbT+ARqrKdRZIS84OUB/aebgNLT+j2bk8L+UoBQuz6J6JHDqz1duoVa5CK5bIopVEBfu44ZBXHdE01XWLgGS1ce027iCCk0VRAAjpKDVG2X83YONxClg+cCOc6EpVXviHsxnoMSyOpgxTXQRgdgmv1XyzbBTyYKKFWbtNg7AUbxQ0ngQf800+0OmHLZ7ooILlRH115DQ0KJQeKyegCdjJ0Uc4uoSlqVF1VXKvwCColWT3MHU/U9Ig6Edqloh8ulM3BVhnORrwYwJ+oScfzPUPkg9kwzDdA4QgAhdKHKjOa9V62vPlz/oq4fD4LRs81BHiHQVo/WFK+UTkvrqYpDi+hiFfuob8N4sUGckXP8eEVyY2XP5fCMzkhwe2Xnz2CvWqoLt6v6LeZzYFQs68ZwGuwfKn22PqkuyvO+H3X4qqe7F60ofIl9OjJCeLuIpGovG13t/ivNlRiVk8OYaYQQK6OGDVhVqeWI81GXNrttPQygLStr6nnaQo6Gawtsrwk5/OL2ztKrzypXMy+8o2AaQyxrtaGJxnDv8MMkiv0AN2r3uAAfpS2N8xaImeD0R6/EB9W/P/S54KzxyCvsgcVQ0OHJq1LmICHipzFL7lSj7wBmlXmaiA=
-        file: multi-geth-$TRAVIS_OS_NAME.*
+        file: ethoxy-*-$TRAVIS_OS_NAME.*
         file_glob: true
         draft: true
         on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,26 +25,26 @@ install:
 
 build_script:
   - go run build\ci.go install
-  - 7z a ethoxy-multi-geth-win64.zip .\build\bin\geth.exe
-  - ps: Get-FileHash ethoxy-multi-geth-win64.zip -Algorithm SHA256
-  - ps: Get-FileHash ethoxy-multi-geth-win64.zip -Algorithm SHA256 | Out-File ethoxy-multi-geth-win64.zip.sha256
-  - 7z a ethoxy-alltools-win64.zip .\build\bin\*
-  - ps: Get-FileHash ethoxy-alltools-win64.zip -Algorithm SHA256
-  - ps: Get-FileHash ethoxy-alltools-win64.zip | Out-File ethoxy-alltools-win64.zip.sha256
+  - 7z a multi-geth-win64.zip .\build\bin\geth.exe
+  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256 | Out-File multi-geth-win64.zip.sha256
+  - 7z a multi-geth-alltools-win64.zip .\build\bin\*
+  - ps: Get-FileHash multi-geth-alltools-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash multi-geth-alltools-win64.zip | Out-File multi-geth-alltools-win64.zip.sha256
 
 artifacts:
-  - path: '*ethoxy-multi-geth*.zip'
+  - path: '*multi-geth*.zip'
     name: geth
-  - path: '*ethoxy-multi-geth*.zip.sha256'
+  - path: '*multi-geth*.zip.sha256'
     name: geth-sha256
-  - path: '*ethoxy-alltools*.zip'
+  - path: '*multi-geth-alltools*.zip'
     name: alltools
-  - path: '*ethoxy-alltools*.zip.sha256'
+  - path: '*multi-geth-alltools*.zip.sha256'
     name: alltools-sha256
 
 deploy:
   provider: GitHub
-  artifact: /ethoxy-.*-win64\.zip.*/
+  artifact: /multi-geth.*-win64\.zip.*/
   auth_token:
     secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
   draft: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,18 +28,32 @@ build_script:
   - 7z a multi-geth-win64.zip .\build\bin\geth.exe
   - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256
   - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256 | Out-File multi-geth-win64.zip.sha256
+  - 7z a ethoxy-alltools-win64.zip .\build\bin\*
+  - ps: Get-FileHash ethoxy-alltools-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash ethoxy-alltools-win64.zip | Out-File ethoxy-alltools-win64.zip.sha256
 
 artifacts:
-  - path: '*.zip'
+  - path: '*multi-geth*.zip'
     name: geth
-  - path: '*.zip.sha256'
+  - path: '*multi-geth*.zip.sha256'
     name: geth-sha256
+  - path: '*ethoxy-alltools*.zip'
+    name: alltools
+  - path: '*ethoxy-alltools*.zip.sha256'
+    name: alltools-sha256
 
 deploy:
-  artifact: /multi-geth-win64\.zip.*/
-  auth_token:
-    secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
-  draft: true
-  on:
-    appveyor_repo_tag: true
-  provider: GitHub
+  - provider: GitHub
+    artifact: /multi-geth-win64\.zip.*/
+    auth_token:
+      secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
+    draft: true
+    on:
+      appveyor_repo_tag: true
+  - provider: GitHub
+    artifact: /ethoxy-alltools-win64\.zip.*/
+    auth_token:
+      secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
+    draft: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,17 +25,17 @@ install:
 
 build_script:
   - go run build\ci.go install
-  - 7z a multi-geth-win64.zip .\build\bin\geth.exe
-  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256
-  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256 | Out-File multi-geth-win64.zip.sha256
+  - 7z a ethoxy-multi-geth-win64.zip .\build\bin\geth.exe
+  - ps: Get-FileHash ethoxy-multi-geth-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash ethoxy-multi-geth-win64.zip -Algorithm SHA256 | Out-File ethoxy-multi-geth-win64.zip.sha256
   - 7z a ethoxy-alltools-win64.zip .\build\bin\*
   - ps: Get-FileHash ethoxy-alltools-win64.zip -Algorithm SHA256
   - ps: Get-FileHash ethoxy-alltools-win64.zip | Out-File ethoxy-alltools-win64.zip.sha256
 
 artifacts:
-  - path: '*multi-geth*.zip'
+  - path: '*ethoxy-multi-geth*.zip'
     name: geth
-  - path: '*multi-geth*.zip.sha256'
+  - path: '*ethoxy-multi-geth*.zip.sha256'
     name: geth-sha256
   - path: '*ethoxy-alltools*.zip'
     name: alltools
@@ -43,17 +43,10 @@ artifacts:
     name: alltools-sha256
 
 deploy:
-  - provider: GitHub
-    artifact: /multi-geth-win64\.zip.*/
-    auth_token:
-      secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
-    draft: true
-    on:
-      appveyor_repo_tag: true
-  - provider: GitHub
-    artifact: /ethoxy-alltools-win64\.zip.*/
-    auth_token:
-      secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
-    draft: true
-    on:
-      appveyor_repo_tag: true
+  provider: GitHub
+  artifact: /ethoxy-.*-win64\.zip.*/
+  auth_token:
+    secure: 6NcsMzxggkLUTrKSB/oJQKMDORkvDIfa39CMSlF0+J4CaPScg3patFk755g+tHfA
+  draft: true
+  on:
+    appveyor_repo_tag: true

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-GETH_ARCHIVE_NAME="ethoxy-multi-geth-$TRAVIS_OS_NAME"
+GETH_ARCHIVE_NAME="multi-geth-$TRAVIS_OS_NAME"
 zip -j "$GETH_ARCHIVE_NAME.zip" build/bin/geth
 
 shasum -a 256 $GETH_ARCHIVE_NAME.zip
 shasum -a 256 $GETH_ARCHIVE_NAME.zip > $GETH_ARCHIVE_NAME.zip.sha256
 
-ETHOXY_ALLTOOLS_ARCHIVE_NAME="ethoxy-alltools-$TRAVIS_OS_NAME"
-zip -j "$ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip" build/bin/*
+ALLTOOLS_ARCHIVE_NAME="multi-geth-alltools-$TRAVIS_OS_NAME"
+zip -j "$ALLTOOLS_ARCHIVE_NAME.zip" build/bin/*
 
-shasum -a 256 $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip
-shasum -a 256 $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip > $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip.sha256
+shasum -a 256 $ALLTOOLS_ARCHIVE_NAME.zip
+shasum -a 256 $ALLTOOLS_ARCHIVE_NAME.zip > $ALLTOOLS_ARCHIVE_NAME.zip.sha256
 

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
-GETH_ARCHIVE_NAME="multi-geth-$TRAVIS_OS_NAME"
+GETH_ARCHIVE_NAME="ethoxy-multi-geth-$TRAVIS_OS_NAME"
 zip -j "$GETH_ARCHIVE_NAME.zip" build/bin/geth
 
 shasum -a 256 $GETH_ARCHIVE_NAME.zip
 shasum -a 256 $GETH_ARCHIVE_NAME.zip > $GETH_ARCHIVE_NAME.zip.sha256
+
+ETHOXY_ALLTOOLS_ARCHIVE_NAME="ethoxy-alltools-$TRAVIS_OS_NAME"
+zip -j "$ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip" build/bin/*
+
+shasum -a 256 $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip
+shasum -a 256 $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip > $ETHOXY_ALLTOOLS_ARCHIVE_NAME.zip.sha256
+


### PR DESCRIPTION
Creates an artifact `ethoxy-alltools-$OS.zip` that contains all available executables:

```
$ tree build/bin
build/bin
├── abigen
├── bootnode
├── clef
├── ethkey
├── evm
├── examples
├── faucet
├── geth
├── mimegen
├── p2psim
├── puppeth
├── rlpdump
├── simulations
├── swarm
├── swarm-smoke
└── wnode
```
