### PR TITLE
Fix/eip articulate 161

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -103,7 +103,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Update the state with pending changes
 	var root []byte
 	if config.IsEIP658F(header.Number) {
-		statedb.Finalise(true)
+		statedb.Finalise(config.IsEIP161F(header.Number))
 	} else {
 		root = statedb.IntermediateRoot(config.IsEIP161F(header.Number)).Bytes()
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -215,7 +215,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 						break
 					}
 					// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
-					task.statedb.Finalise(api.eth.blockchain.Config().IsEIP158HF(task.block.Number()))
+					task.statedb.Finalise(api.eth.blockchain.Config().IsEIP161F(task.block.Number()))
 					task.results[i] = &txTraceResult{Result: res}
 				}
 				// Stream the result back to the user or abort on teardown
@@ -508,7 +508,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}
 		// Finalize the state so any modifications are written to the trie
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
-		statedb.Finalise(vmenv.ChainConfig().IsEIP158HF(block.Number()))
+		statedb.Finalise(vmenv.ChainConfig().IsEIP161F(block.Number()))
 	}
 	close(jobs)
 	pend.Wait()
@@ -615,7 +615,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 		// Finalize the state so any modifications are written to the trie
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
-		statedb.Finalise(vmenv.ChainConfig().IsEIP158HF(block.Number()))
+		statedb.Finalise(vmenv.ChainConfig().IsEIP161F(block.Number()))
 
 		// If we've traced the transaction we were looking for, abort
 		if tx.Hash() == txHash {
@@ -807,7 +807,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 		}
 		// Ensure any modifications are committed to the state
 		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
-		statedb.Finalise(vmenv.ChainConfig().IsEIP158HF(block.Number()))
+		statedb.Finalise(vmenv.ChainConfig().IsEIP161F(block.Number()))
 	}
 	return nil, vm.Context{}, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, blockHash)
 }


### PR DESCRIPTION
eth/api_tracer.go: This just fixes some missed `IsEIP158HF` calls, updating them to corresponding `IsEIP161F`s.

core/state_processor.go: this fixes a place where `true` was hardcoded b/c it was assumed that the `EIP158` fork would be in place