### PR TITLE
core: add Kotti switch to configOrDefault fn

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -225,6 +225,8 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 		return params.MixChainConfig
 	case ghash == params.EthersocialGenesisHash:
 		return params.EthersocialChainConfig
+	case ghash == params.KottiGenesisHash:
+		return params.KottiChainConfig
 	default:
 		return params.AllEthashProtocolChanges
 	}


### PR DESCRIPTION
Kotti switch was missing. I believe this should only have impacted some edge cases, since the `switch` returns on an existing `genesis.Config`.