### PR TITLE
Changed block-gas-limit default to 2,000,000

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -51,8 +51,8 @@ var DefaultConfig = Config{
 	TrieDirtyCache:     256,
 	TrieTimeout:        60 * time.Minute,
 	Miner: miner.Config{
-		GasFloor: 8000000,
-		GasCeil:  8000000,
+		GasFloor: 2000000,
+		GasCeil:  2000000,
 		GasPrice: big.NewInt(params.GWei),
 		Recommit: 3 * time.Second,
 	},


### PR DESCRIPTION
As per some discussions, [calls](https://github.com/ethereumclassic/ECIPs/issues/252), and ECIP-1047