### PR TITLE
Add Phoenix hard fork support for Kotti and Mordor

### DIFF
--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -38,6 +38,7 @@ var (
 		ByzantiumBlock:      big.NewInt(716617),
 		ConstantinopleBlock: big.NewInt(1705549),
 		PetersburgBlock:     big.NewInt(1705549),
+		IstanbulBlock:       big.NewInt(2200013),
 		DisposalBlock:       big.NewInt(0),
 		ECIP1017EraRounds:   big.NewInt(5000000),
 		EIP160Block:         big.NewInt(0),

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -35,6 +35,7 @@ var (
 		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: big.NewInt(301243),
 		PetersburgBlock:     big.NewInt(301243),
+		IstanbulBlock:       big.NewInt(999983),
 		DisposalBlock:       big.NewInt(0),
 		ECIP1017EraRounds:   big.NewInt(2000000),
 		EIP160Block:         big.NewInt(0),


### PR DESCRIPTION
This implements [Phoenix](https://consensus.corepaper.org/wiki/Phoenix_(new)) hard fork support for Kotti and Mordor testnets. Ref https://github.com/multi-geth/rfcs/issues/1